### PR TITLE
Improve database performance for mass transactions

### DIFF
--- a/app/src/main/java/org/woheller69/weather/weather_api/open_meteo/ProcessOMweatherAPIRequest.java
+++ b/app/src/main/java/org/woheller69/weather/weather_api/open_meteo/ProcessOMweatherAPIRequest.java
@@ -73,6 +73,7 @@ public class ProcessOMweatherAPIRequest implements IProcessHttpRequest {
         IDataExtractor extractor = new OMDataExtractor(context);
         try {
             JSONObject json = new JSONObject(response);
+            dbHelper.beginTransaction();
 
             //Extract daily weather
             dbHelper.deleteWeekForecastsByCityId(cityId);
@@ -140,6 +141,7 @@ public class ProcessOMweatherAPIRequest implements IProcessHttpRequest {
                     dbHelper.addWeekForecast(weekForecast);
                 }
             }
+            dbHelper.endTransaction(true);
 
             possiblyUpdateWidgets(cityId, weatherData, weekforecasts,hourlyforecasts);
 
@@ -148,6 +150,7 @@ public class ProcessOMweatherAPIRequest implements IProcessHttpRequest {
             ViewUpdater.updateForecasts(hourlyforecasts);
 
         } catch (JSONException e) {
+            dbHelper.endTransaction(false);
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
Currently the database is closed after each write operation, which is means that the `close` and the next `getWritableDatabase` will take a while.
In case of my ancient S4 mini this is about 10-20 ms for each `close` and `getWritableDatabase`.

This is acceptable for small operations, but in case of many writes (like `ProcessOMweatherAPIRequest.processSuccessScenario`) the opening / closing quickly sums up to several seconds.

This PR uses `beginTransaction` and `endTransaction` to greatly speed up mass write operations, and avoids closing the database while a transaction is running.
This effectively reduces the time for `ProcessOMweatherAPIRequest.processSuccessScenario` when refreshing weather data from ca 10 seconds to less than 1 second.
If `setTransactionSuccessful` is not set before `endTransaction`, all writes since `beginTransaction` are discarded.

When a mass transaction is not explicitly requested using `beginTransaction`, database behavior is unchanged.