### PR TITLE
Add precipitation in inches

### DIFF
--- a/app/src/main/java/org/woheller69/weather/preferences/AppPreferencesManager.java
+++ b/app/src/main/java/org/woheller69/weather/preferences/AppPreferencesManager.java
@@ -92,4 +92,9 @@ public class AppPreferencesManager {
         editor.putBoolean("askForStar", askForStar);
         editor.apply();
     }
+
+    public boolean showMetricPrecipitation() {
+        int prefValue = Integer.parseInt(preferences.getString("precipitationUnit", "1"));
+        return prefValue == 1;
+    }
 }

--- a/app/src/main/java/org/woheller69/weather/ui/Help/StringFormatUtils.java
+++ b/app/src/main/java/org/woheller69/weather/ui/Help/StringFormatUtils.java
@@ -57,8 +57,15 @@ public final class StringFormatUtils {
     }
 
     public static String formatPrecipitation(Context context, float precipitation) {
-        if (precipitation < 10.0f) return formatDecimal(precipitation, context.getString(R.string.units_mm)); //show decimal only below 10mm
-        else return formatInt(precipitation,context.getString(R.string.units_mm));
+        AppPreferencesManager prefManager = new AppPreferencesManager(PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()));
+        if (prefManager.showMetricPrecipitation()) {
+            if (precipitation < 10.0f) return formatDecimal(precipitation, context.getString(R.string.units_mm)); //show decimal only below 10mm
+            else return formatInt(precipitation,context.getString(R.string.units_mm));
+        } else {
+            DecimalFormat inchFormatter = new DecimalFormat("0.00");
+            inchFormatter.setRoundingMode(RoundingMode.HALF_UP);
+            return String.format("%s\u200a%s", removeMinusIfZerosOnly(inchFormatter.format(precipitation / 25.4)), content.getString(R.string.units_in));
+        }
     }
 
     public static String formatTimeWithoutZone(Context context, long time) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -19,6 +19,15 @@
         <item>2</item>
     </string-array>
 
+    <string-array name="precipitationUnitsArray">
+        <item>@string/settings_precipitation_mm</item>
+        <item>@string/settings_precipitation_in</item>
+    </string-array>
+    <string-array name="precipitationUnitsValues">
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
     <string-array name="refreshIntervalArray">
         <item>@string/settings_interval_quarter</item>
         <item>@string/settings_interval_half</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,10 @@
     <string name="settings_title_distance">Distances</string>
     <string name="settings_kilometers">Kilometers</string>
     <string name="settings_miles">Miles</string>
+    <string name="settings_title_precipitation_units">Precipitation Units</string>
+    <string name="settings_summary_precipitation_unit">Set the unit to use for displaying precipitation</string>
+    <string name="settings_precipitation_mm">Millimeters</string>
+    <string name="settings_precipitation_in">Inches</string>
     <string name="abbreviation_monday">Mo.</string>
     <string name="abbreviation_tuesday">Tu.</string>
     <string name="abbreviation_wednesday">We.</string>
@@ -83,10 +87,12 @@
     <string name="chart">Chart</string>
     <string name="units_rh">% rh</string>
     <string name="units_mm">mm</string>
+    <string name="units_in">in</string>
     <string name="units_km">km</string>
     <string name="units_hPa">hPa</string>
     <string name="units_Bft">Bft</string>
     <string name="units_mm_h">mm/h</string>
+    <string name="units_in_h">in/h</string>
     <string name="units_km_h">km/h</string>
     <string name="units_mph">mph</string>
     <string name="card_details_rain60min">☔ 60 min:</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -98,6 +98,15 @@
             android:summary="@string/settings_summary_distance"
             android:title="@string/settings_title_distance" />
 
+        <ListPreference
+            app:useSimpleSummaryProvider="true"
+            android:defaultValue="1"
+            android:entries="@array/precipitationUnitsArray"
+            android:entryValues="@array/precipitationUnitsValues"
+            android:key="precipitationUnit"
+            android:summary="@string/settings_summary_precipitation_unit"
+            android:title="@string/settings_title_precipitation_units" />
+
         <SwitchPreference
             android:key="pref_WindFormat"
             android:title="@string/settings_wind"


### PR DESCRIPTION
This is meant to address #21 

First of all, thanks for your work on this app! I find it very useful each day and I appreciate all the work that you've put into it.

Now on to this PR. I would find it useful to have the option to switch precipitation to display in inches rather than millimeters. It's not that I can't get a good approximate converted value mentally, it's just that I'd rather not have to. So I'd like to get the effort started. Now, I'm really not an Android dev, not even a java dev, so I'm sure there's more to be done with this code before it can be merged. I've reached the limit of where I feel comfortable inferring code patterns, etc. from the existing codebase, so I figured I'd submit this as a draft and ask for help getting it over the finish line. I'm happy to do as much of the remaining work as I can, but I need to be pointed in the right direction.

Some things I can already tell you I didn't touch and would appreciate some assistance:
- None of the new strings have been added to any of the localization files (and unless services like Google Translate are adequate starting points, I'm unable to do most of the translations 😅)
- I have no idea if this change breaks the tests, as I have no idea how to run the tests (see above, I'm not a java dev)

Thanks for your patience and I'd appreciate any assistance you can offer to get this merge-ready.